### PR TITLE
DEVOPS-7574 erb-hiera: exit with an error code if a child did.

### DIFF
--- a/lib/erb-hiera.rb
+++ b/lib/erb-hiera.rb
@@ -33,7 +33,16 @@ module ErbHiera
       end
     end
     unless options[:no_fork] then
-      Process.waitall
+      exit_status = 0
+      forked_statuses = Process.waitall
+      forked_statuses.each{|forked_status|
+        if forked_status[1].exitstatus != 0 then
+          exit_status = forked_status[1].exitstatus
+          p forked_status
+          p forked_pids[forked_status[0]]
+        end
+      }
+      exit exit_status if exit_status != 0
     end
   rescue => error
     handle_error(error)


### PR DESCRIPTION
Putting the change I removed in https://github.com/GannettDigital/erb-hiera/pull/3/commits/a67b1929df16fb1ea8bb7d6110dc1d96eea6f3aa back.

We want changes like https://github.com/GannettDigital/rl-platform-gke-configs/runs/6329370219?check_suite_focus=true#step:7:11 to fail in github actions.